### PR TITLE
Shared package is not a tool

### DIFF
--- a/src/DendroDocs.Shared/DendroDocs.Shared.csproj
+++ b/src/DendroDocs.Shared/DendroDocs.Shared.csproj
@@ -8,9 +8,6 @@
 
 		<RootNamespace>DendroDocs</RootNamespace>
 		
-		<PackAsTool>true</PackAsTool>
-		<ToolCommandName>dendrodocs-analyze</ToolCommandName>
-
 		<Authors>Michaël Hompus</Authors>
 		<PackageProjectUrl>https://github.com/DendroDocs/dotnet-shared-lib</PackageProjectUrl>
 		<Description></Description>


### PR DESCRIPTION
# Pull Request Template

## Description

Package is now listed on nuget.org as a tool, but `Shared` is not a tool.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Local pack

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes

