### PR TITLE
Fix BaseTypes deserialization with System.Text.Json

### DIFF
--- a/src/DendroDocs.Shared/Descriptions/TypeDescription.cs
+++ b/src/DendroDocs.Shared/Descriptions/TypeDescription.cs
@@ -16,7 +16,8 @@ public class TypeDescription(TypeType type, string? fullName) : IHaveModifiers
         IReadOnlyList<MethodDescription> methods,
         IReadOnlyList<EnumMemberDescription> enumMembers,
         IReadOnlyList<EventDescription> events,
-        List<AttributeDescription> attributes
+        List<AttributeDescription> attributes,
+        List<string> baseTypes
     )
         : this(type, fullName)
     {
@@ -27,6 +28,7 @@ public class TypeDescription(TypeType type, string? fullName) : IHaveModifiers
         if (enumMembers is not null) this.enumMembers = [.. enumMembers];
         if (events is not null) this.events = [.. events];
         if (attributes is not null) this.Attributes.AddRange(attributes);
+        if (baseTypes is not null) this.BaseTypes.AddRange(baseTypes);
     }
 
     [Newtonsoft.Json.JsonProperty(Order = 1, PropertyName = nameof(Fields))]

--- a/tests/DendroDocs.Shared.Tests/Serialization/NewtonsoftDeserializationTests.cs
+++ b/tests/DendroDocs.Shared.Tests/Serialization/NewtonsoftDeserializationTests.cs
@@ -369,4 +369,26 @@ public class NewtonsoftDeserializationTests
         var @switch = (Switch)types[0].Methods[0].Statements[0];
         @switch.Sections[0].Statements[0].Parent.ShouldBe(@switch.Sections[0]);
     }
+
+    [TestMethod]
+    public void BaseTypes_Should_BeDeserializedCorrectly()
+    {
+        // Assign
+        var json = @"[{
+            ""FullName"": ""Pitstop.TimeService.Events.DayHasPassed"",
+            ""BaseTypes"": [
+                ""Pitstop.Infrastructure.Messaging.Event"",
+                ""System.Object""
+            ]
+        }]";
+
+        // Act
+        var types = JsonConvert.DeserializeObject<List<TypeDescription>>(json, JsonDefaults.DeserializerSettings())!;
+
+        // Assert
+        types.Count.ShouldBe(1);
+        types[0].BaseTypes.Count.ShouldBe(2);
+        types[0].BaseTypes.ShouldContain("Pitstop.Infrastructure.Messaging.Event");
+        types[0].BaseTypes.ShouldContain("System.Object");
+    }
 }

--- a/tests/DendroDocs.Shared.Tests/Serialization/TextJsonDeserializationTests.cs
+++ b/tests/DendroDocs.Shared.Tests/Serialization/TextJsonDeserializationTests.cs
@@ -455,4 +455,29 @@ public class TextJsonDeserializationTests
         types[0].Methods[0].Name.ShouldBe("VoidMethod");
         types[0].Methods[0].ReturnType.ShouldBe("void");
     }
+
+    [TestMethod]
+    public void BaseTypes_Should_BeDeserializedCorrectly()
+    {
+        // Assign
+        var json =
+            """
+            [{
+                "FullName": "Pitstop.TimeService.Events.DayHasPassed",
+                "BaseTypes": [
+                    "Pitstop.Infrastructure.Messaging.Event",
+                    "System.Object"
+                ]
+            }]
+            """;
+
+        // Act
+        var types = JsonSerializer.Deserialize<List<TypeDescription>>(json, JsonDefaults.DeserializerOptions())!;
+
+        // Assert
+        types.Count.ShouldBe(1);
+        types[0].BaseTypes.Count.ShouldBe(2);
+        types[0].BaseTypes.ShouldContain("Pitstop.Infrastructure.Messaging.Event");
+        types[0].BaseTypes.ShouldContain("System.Object");
+    }
 }


### PR DESCRIPTION
* Fix BaseTypes deserialization with System.Text.Json - add BaseTypes parameter to JsonConstructor
